### PR TITLE
Proposal to allow ++/-- unary operators in loop afterthoughts

### DIFF
--- a/eslint-config/.eslintrc.js
+++ b/eslint-config/.eslintrc.js
@@ -29,6 +29,12 @@ module.exports = {
             ERROR,
             'always'
         ],
+        'no-plusplus': [
+            ERROR,
+            {
+                'allowForLoopAfterthoughts': true
+            }
+        ],
 
         // React Rules
         'react/jsx-indent': [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Proposal to allow `++` (or `--`) unary operators in loop afterthoughts since automatic semicolon insertion should not be an issue here. ([Read about the eslint exception here](https://eslint.org/docs/rules/no-plusplus#options))

This would allow us to use the good old 
```javascript
for(let i = 0; i < 10; i++) {
// do something
}
```
rather than the proposed 
```javascript
for(let i= 0; i < 10; i+=1) {
// do something
} 
```